### PR TITLE
Damage animations/indicators

### DIFF
--- a/cards/dragon/card.tscn
+++ b/cards/dragon/card.tscn
@@ -1,7 +1,10 @@
-[gd_scene load_steps=10 format=3 uid="uid://bd33jd7cgnam0"]
+[gd_scene load_steps=11 format=3 uid="uid://bd33jd7cgnam0"]
 
 [ext_resource type="PackedScene" uid="uid://dxdy4c55rwyag" path="res://components/card_prefab.tscn" id="1_erpla"]
 [ext_resource type="Texture2D" uid="uid://d4dq3knlwss5f" path="res://cards/dragon/card_dragon.png" id="2_6jg6s"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_oallc"]
+viewport_path = NodePath("DamageIndicatorViewport")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sn4no"]
 albedo_texture = ExtResource("2_6jg6s")
@@ -36,6 +39,9 @@ toughness = 5
 flavortext = "Its very presence is terrifying"
 description = "[color=41e18e][b]Announcement[/b][/color]: Deal 5 damage to all enemies."
 
+[node name="DamageIndicatorSprite" parent="." index="0"]
+texture = SubResource("ViewportTexture_oallc")
+
 [node name="counterspell_card" parent="card" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_sn4no")
 
@@ -52,5 +58,5 @@ texture = SubResource("ViewportTexture_0tvsc")
 [node name="TitleSprite" parent="card" index="5"]
 texture = SubResource("ViewportTexture_4gh7w")
 
-[node name="CollisionShape3D" parent="." index="1"]
+[node name="CollisionShape3D" parent="." index="2"]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, -0.00283813, -0.00924338, 0.00246477)

--- a/components/avatar.tscn
+++ b/components/avatar.tscn
@@ -17,6 +17,33 @@ viewport_path = NodePath("SubViewport")
 [sub_resource type="ViewportTexture" id="ViewportTexture_qacib"]
 viewport_path = NodePath("DamageIndicatorViewport")
 
+[sub_resource type="Animation" id="Animation_4fe75"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("DamageIndicatorSprite:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("DamageIndicatorSprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(1, 1, 1)]
+}
+
 [sub_resource type="Animation" id="Animation_v8rs8"]
 resource_name = "avatar_damaged"
 length = 0.3
@@ -42,34 +69,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 0.0333333, 0.266667, 0.3),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
-"values": [Vector3(0, 0, 0), Vector3(1, 1, 1), Vector3(2, 2, 2), Vector3(0, 0, 0)]
-}
-
-[sub_resource type="Animation" id="Animation_4fe75"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("DamageIndicatorSprite:position")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector3(0, 0, 1)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("DamageIndicatorSprite:scale")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Vector3(0, 0, 0)]
+"values": [Vector3(1, 1, 1), Vector3(0.75, 0.75, 0.75), Vector3(1.5, 1.5, 1.5), Vector3(0, 0, 0)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_s4v35"]
@@ -229,7 +229,7 @@ scroll_active = false
 autowrap_mode = 0
 
 [node name="DamageIndicatorSprite" type="Sprite3D" parent="."]
-transform = Transform3D(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1)
 texture = SubResource("ViewportTexture_qacib")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/components/avatar.tscn
+++ b/components/avatar.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://4cw3cdp1kc87"]
+[gd_scene load_steps=12 format=3 uid="uid://4cw3cdp1kc87"]
 
 [ext_resource type="Script" path="res://scripts/Avatar.gd" id="1_qm4ao"]
 [ext_resource type="Texture2D" uid="uid://b47mnp8qk81lr" path="res://art/hackclub/anonymous.png" id="2_aenoy"]
@@ -12,9 +12,76 @@ viewport_path = NodePath("SubViewport")
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_8u3be"]
 
-[node name="Avatar" type="Node3D" node_paths=PackedStringArray("toughness_text")]
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_f5s0n"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_qacib"]
+viewport_path = NodePath("DamageIndicatorViewport")
+
+[sub_resource type="Animation" id="Animation_v8rs8"]
+resource_name = "avatar_damaged"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("DamageIndicatorSprite:position")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, -0.5, 0.3), Vector3(0, 0.25, 0.3)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("DamageIndicatorSprite:scale")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.266667, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(1, 1, 1), Vector3(2, 2, 2), Vector3(0, 0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_4fe75"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("DamageIndicatorSprite:position")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("DamageIndicatorSprite:scale")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 0)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_s4v35"]
+_data = {
+"RESET": SubResource("Animation_4fe75"),
+"avatar_damaged": SubResource("Animation_v8rs8")
+}
+
+[node name="Avatar" type="Node3D" node_paths=PackedStringArray("toughness_text", "damage_indicator_label")]
 script = ExtResource("1_qm4ao")
 toughness_text = NodePath("SubViewport/Control/Avatar2/NinePatchRect/NinePatchRect/ToughnessRichTextLabel")
+damage_indicator_label = NodePath("DamageIndicatorViewport/DamageIndicatorPanel/DamageIndicatorLabel")
 
 [node name="RigidBody3D" type="RigidBody3D" parent="."]
 axis_lock_linear_x = true
@@ -29,6 +96,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0171814, -0.0847778, -0.007
 shape = SubResource("BoxShape3D_6p20s")
 
 [node name="AvatarSprite" type="Sprite3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0042569, 0.00373971, -0.000514865)
 texture = SubResource("ViewportTexture_bqatu")
 
 [node name="SubViewport" type="SubViewport" parent="."]
@@ -122,6 +190,52 @@ bbcode_enabled = true
 text = "[center]20[/center]"
 fit_content = true
 scroll_active = false
+
+[node name="DamageIndicatorViewport" type="SubViewport" parent="."]
+transparent_bg = true
+size = Vector2i(128, 128)
+render_target_update_mode = 4
+
+[node name="DamageIndicatorPanel" type="Panel" parent="DamageIndicatorViewport"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_f5s0n")
+
+[node name="DamageIndicatorLabel" type="RichTextLabel" parent="DamageIndicatorViewport/DamageIndicatorPanel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -12.0
+offset_top = -27.5
+offset_right = 12.0
+offset_bottom = 27.5
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(64, 61)
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0.2757, 0.2757, 0.2757, 1)
+theme_override_font_sizes/normal_font_size = 40
+theme_override_font_sizes/bold_font_size = 40
+bbcode_enabled = true
+text = "[color=ff0000][center][b]-5[/b][/center]"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0
+
+[node name="DamageIndicatorSprite" type="Sprite3D" parent="."]
+transform = Transform3D(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+texture = SubResource("ViewportTexture_qacib")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_s4v35")
+}
 
 [connection signal="mouse_entered" from="RigidBody3D" to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="RigidBody3D" to="." method="_on_mouse_exited"]

--- a/components/avatar.tscn
+++ b/components/avatar.tscn
@@ -43,10 +43,22 @@ tracks/1/keys = {
 "update": 0,
 "values": [Vector3(0, 0, 0)]
 }
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("AvatarSprite:rotation")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 0)]
+}
 
 [sub_resource type="Animation" id="Animation_v8rs8"]
 resource_name = "avatar_damaged"
-length = 0.3
+length = 0.7
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -54,10 +66,10 @@ tracks/0/path = NodePath("DamageIndicatorSprite:position")
 tracks/0/interp = 2
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.3),
+"times": PackedFloat32Array(0, 0.7),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector3(0, -0.5, 0.3), Vector3(0, 0.25, 0.3)]
+"values": [Vector3(0, -0.5, 0.4), Vector3(0, 0.25, 0.4)]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -66,10 +78,22 @@ tracks/1/path = NodePath("DamageIndicatorSprite:scale")
 tracks/1/interp = 2
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.266667, 0.3),
+"times": PackedFloat32Array(0, 0.0666667, 0.633333, 0.7),
 "transitions": PackedFloat32Array(1, 1, 1, 1),
 "update": 0,
 "values": [Vector3(1, 1, 1), Vector3(0.75, 0.75, 0.75), Vector3(1.5, 1.5, 1.5), Vector3(0, 0, 0)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("AvatarSprite:rotation")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.7),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 0, 0)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_s4v35"]

--- a/components/avatar.tscn
+++ b/components/avatar.tscn
@@ -41,7 +41,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0),
 "transitions": PackedFloat32Array(1),
 "update": 0,
-"values": [Vector3(1, 1, 1)]
+"values": [Vector3(0, 0, 0)]
 }
 
 [sub_resource type="Animation" id="Animation_v8rs8"]
@@ -229,7 +229,7 @@ scroll_active = false
 autowrap_mode = 0
 
 [node name="DamageIndicatorSprite" type="Sprite3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1)
+transform = Transform3D(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
 texture = SubResource("ViewportTexture_qacib")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/components/card_prefab.tscn
+++ b/components/card_prefab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=43 format=4 uid="uid://dxdy4c55rwyag"]
+[gd_scene load_steps=41 format=4 uid="uid://dxdy4c55rwyag"]
 
 [ext_resource type="Script" path="res://scripts/CardController.gd" id="1_pfeis"]
 [ext_resource type="Resource" uid="uid://d3f4j3k5ep0ew" path="res://sounds/defaults.tres" id="2_r6i3w"]
@@ -177,6 +177,9 @@ viewport_path = NodePath("CostViewport")
 [sub_resource type="ViewportTexture" id="ViewportTexture_nflyd"]
 viewport_path = NodePath("TitleViewport")
 
+[sub_resource type="ViewportTexture" id="ViewportTexture_4sttb"]
+viewport_path = NodePath("TiredViewport")
+
 [sub_resource type="BoxShape3D" id="BoxShape3D_huxpf"]
 size = Vector3(3.63873, 4.99524, 0.0436401)
 
@@ -269,7 +272,7 @@ tracks/6/keys = {
 
 [sub_resource type="Animation" id="Animation_dobx1"]
 resource_name = "damaged"
-length = 0.5
+length = 0.7
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -277,7 +280,7 @@ tracks/0/path = NodePath("card:rotation")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"times": PackedFloat32Array(0, 0.0333333, 0.166667, 0.333333, 0.6),
 "transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
 "update": 0,
 "values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
@@ -289,7 +292,7 @@ tracks/1/path = NodePath("CollisionShape3D:rotation")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"times": PackedFloat32Array(0, 0.0333333, 0.166667, 0.333333, 0.6),
 "transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
 "update": 0,
 "values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
@@ -301,10 +304,10 @@ tracks/2/path = NodePath("DamageIndicatorSprite:position")
 tracks/2/interp = 2
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.5),
+"times": PackedFloat32Array(0, 0.666667),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
+"values": [Vector3(0.9, -1, 0.025), Vector3(0.9, 0, 0.025)]
 }
 tracks/3/type = "value"
 tracks/3/imported = false
@@ -313,59 +316,7 @@ tracks/3/path = NodePath("DamageIndicatorSprite:scale")
 tracks/3/interp = 2
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"times": PackedFloat32Array(0, 0.333333, 0.5),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
-}
-
-[sub_resource type="Animation" id="Animation_q22v4"]
-resource_name = "damaged_tapped"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("card:rotation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CollisionShape3D:rotation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("DamageIndicatorSprite:position")
-tracks/2/interp = 2
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("DamageIndicatorSprite:scale")
-tracks/3/interp = 2
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0, 0.333333, 0.5),
+"times": PackedFloat32Array(0, 0.566667, 0.666667),
 "transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
 "values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
@@ -453,34 +404,6 @@ tracks/2/keys = {
 "values": [Vector3(0, 0, 0.3), Vector3(0, 0, 0)]
 }
 
-[sub_resource type="Animation" id="Animation_djkyf"]
-resource_name = "tap"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("card:rotation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(0.3, 2),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0, 0, -1.5708)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CollisionShape3D:rotation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(0.3, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0, 0, -1.5708)]
-}
-
 [sub_resource type="Animation" id="Animation_ffm8s"]
 resource_name = "turn_down"
 length = 0.5
@@ -513,45 +436,14 @@ tracks/0/keys = {
 "values": [Vector3(0, 3.14159, 0), Vector3(0, 0, 0)]
 }
 
-[sub_resource type="Animation" id="Animation_8o8kj"]
-resource_name = "untap"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("card:rotation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(0.2, 0.01),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, 0)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CollisionShape3D:rotation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(0.3, 1),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, 0)]
-}
-
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_cjtkg"]
 _data = {
 "RESET": SubResource("Animation_1yn1y"),
 "damaged": SubResource("Animation_dobx1"),
-"damaged_tapped": SubResource("Animation_q22v4"),
 "hover_begin": SubResource("Animation_h51jn"),
 "hover_end": SubResource("Animation_j52lu"),
-"tap": SubResource("Animation_djkyf"),
 "turn_down": SubResource("Animation_ffm8s"),
-"turn_up": SubResource("Animation_ts05e"),
-"untap": SubResource("Animation_8o8kj")
+"turn_up": SubResource("Animation_ts05e")
 }
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_btjd5"]
@@ -562,7 +454,7 @@ _data = {
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2upq3"]
 
-[node name="Card" type="RigidBody3D" node_paths=PackedStringArray("label_title", "label_power", "label_toughness", "label_casting_cost", "label_flavortext", "label_subtype", "label_description", "label_type", "label_damage_indicator", "power_container", "toughness_container", "cost_container")]
+[node name="Card" type="RigidBody3D" node_paths=PackedStringArray("label_title", "label_power", "label_toughness", "label_casting_cost", "label_flavortext", "label_subtype", "label_description", "label_type", "label_damage_indicator", "label_asleep_indicator", "power_container", "toughness_container", "cost_container")]
 gravity_scale = 0.0
 script = ExtResource("1_pfeis")
 description = "[color=41e18e][b]Replace me[/b][/color]: Does something generic.  Please replace this with your own text."
@@ -575,6 +467,7 @@ label_subtype = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxConta
 label_description = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxContainer/VBoxContainer/Description")
 label_type = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxContainer/TitleContainerHBox/CardType")
 label_damage_indicator = NodePath("DamageIndicatorViewport/DamageIndicatorPanel/DamageIndicatorLabel")
+label_asleep_indicator = NodePath("TiredViewport/Panel/TiredLabel")
 power_container = NodePath("PowerToughnessViewport/Panel/TitleBackground/PowerContainer")
 toughness_container = NodePath("PowerToughnessViewport/Panel/TitleBackground/ToughnessContainer")
 cost_container = NodePath("card/CastingCostSprite")
@@ -624,6 +517,12 @@ texture = SubResource("ViewportTexture_dk2me")
 [node name="TitleSprite" type="Sprite3D" parent="card"]
 transform = Transform3D(0.64, 0, 0, 0, 0.64, 0, 0, 0, 1, 0, -0.236297, 0.0206564)
 texture = SubResource("ViewportTexture_nflyd")
+
+[node name="TiredLabelSprite" type="Sprite3D" parent="card"]
+transform = Transform3D(0.325965, -0.248031, 0, 0.248031, 0.325965, 0, 0, 0, 2.40537, 0.457929, 0.706594, 0.0999313)
+modulate = Color(0, 1, 0, 1)
+pixel_size = 0.059
+texture = SubResource("ViewportTexture_4sttb")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, -0.0409518, -0.0836923, 0.00246477)
@@ -1085,5 +984,47 @@ theme_override_font_sizes/bold_font_size = 40
 bbcode_enabled = true
 text = "[color=ff0000][center][b]-5[/b][/center]"
 fit_content = true
+scroll_active = false
+autowrap_mode = 0
+
+[node name="TiredViewport" type="SubViewport" parent="."]
+transparent_bg = true
+size = Vector2i(512, 128)
+render_target_update_mode = 4
+
+[node name="Panel" type="Panel" parent="TiredViewport"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -64.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("8_lkgco")
+theme_override_styles/panel = SubResource("StyleBoxEmpty_bqnan")
+
+[node name="TiredLabel" type="RichTextLabel" parent="TiredViewport/Panel"]
+custom_minimum_size = Vector2(359.25, 36.09)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -179.625
+offset_top = -18.045
+offset_right = 179.625
+offset_bottom = 18.045
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(779.104, -126.758)
+theme = ExtResource("8_lkgco")
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_y = 2
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_outline_size = 4
+theme_override_font_sizes/bold_font_size = 35
+bbcode_enabled = true
+text = "[center][b]ASLEEP[/b][/center]"
 scroll_active = false
 autowrap_mode = 0

--- a/components/card_prefab.tscn
+++ b/components/card_prefab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=40 format=4 uid="uid://dxdy4c55rwyag"]
+[gd_scene load_steps=43 format=4 uid="uid://dxdy4c55rwyag"]
 
 [ext_resource type="Script" path="res://scripts/CardController.gd" id="1_pfeis"]
 [ext_resource type="Resource" uid="uid://d3f4j3k5ep0ew" path="res://sounds/defaults.tres" id="2_r6i3w"]
@@ -12,6 +12,9 @@
 [ext_resource type="Texture2D" uid="uid://bhpqonfiembbk" path="res://art/hackclub/pow.png" id="11_5iwf3"]
 [ext_resource type="Texture2D" uid="uid://bphjgh2fp7hvk" path="res://art/hackclub/heart.png" id="12_7mteo"]
 [ext_resource type="Texture2D" uid="uid://b8l3hckrx43uy" path="res://art/card_skin_template/background_rect_4xlight.png" id="12_vak35"]
+
+[sub_resource type="ViewportTexture" id="ViewportTexture_1snw7"]
+viewport_path = NodePath("DamageIndicatorViewport")
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_mx6a1"]
 resource_name = "Card Image"
@@ -239,6 +242,30 @@ tracks/4/keys = {
 "update": 0,
 "values": [Vector3(0, 0, 0)]
 }
+tracks/5/type = "value"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("DamageIndicatorSprite:position")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 0)]
+}
+tracks/6/type = "value"
+tracks/6/imported = false
+tracks/6/enabled = true
+tracks/6/path = NodePath("DamageIndicatorSprite:scale")
+tracks/6/interp = 1
+tracks/6/loop_wrap = true
+tracks/6/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Vector3(0, 0, 0)]
+}
 
 [sub_resource type="Animation" id="Animation_h51jn"]
 resource_name = "hover_begin"
@@ -410,9 +437,115 @@ tracks/1/keys = {
 "values": [Vector3(0, 0, -1.5708), Vector3(0, 0, 0)]
 }
 
+[sub_resource type="Animation" id="Animation_dobx1"]
+resource_name = "damaged"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("card:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape3D:rotation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DamageIndicatorSprite:position")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DamageIndicatorSprite:scale")
+tracks/3/interp = 2
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.333333, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_q22v4"]
+resource_name = "damaged_tapped"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("card:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape3D:rotation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DamageIndicatorSprite:position")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DamageIndicatorSprite:scale")
+tracks/3/interp = 2
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.333333, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
+}
+
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_cjtkg"]
 _data = {
 "RESET": SubResource("Animation_1yn1y"),
+"damaged": SubResource("Animation_dobx1"),
+"damaged_tapped": SubResource("Animation_q22v4"),
 "hover_begin": SubResource("Animation_h51jn"),
 "hover_end": SubResource("Animation_j52lu"),
 "tap": SubResource("Animation_djkyf"),
@@ -429,7 +562,7 @@ _data = {
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2upq3"]
 
-[node name="Card" type="RigidBody3D" node_paths=PackedStringArray("label_title", "label_power", "label_toughness", "label_casting_cost", "label_flavortext", "label_subtype", "label_description", "label_type", "power_container", "toughness_container", "cost_container")]
+[node name="Card" type="RigidBody3D" node_paths=PackedStringArray("label_title", "label_power", "label_toughness", "label_casting_cost", "label_flavortext", "label_subtype", "label_description", "label_type", "label_damage_indicator", "power_container", "toughness_container", "cost_container")]
 gravity_scale = 0.0
 script = ExtResource("1_pfeis")
 description = "[color=41e18e][b]Replace me[/b][/color]: Does something generic.  Please replace this with your own text."
@@ -441,10 +574,17 @@ label_flavortext = NodePath("DescriptionViewport/CardInfo/MarginContainer2/Contr
 label_subtype = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxContainer/TitleContainerHBox/Subtype")
 label_description = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxContainer/VBoxContainer/Description")
 label_type = NodePath("DescriptionViewport/CardInfo/MarginContainer/VBoxContainer/TitleContainerHBox/CardType")
+label_damage_indicator = NodePath("DamageIndicatorViewport/DamageIndicatorPanel/DamageIndicatorLabel")
 power_container = NodePath("PowerToughnessViewport/Panel/TitleBackground/PowerContainer")
 toughness_container = NodePath("PowerToughnessViewport/Panel/TitleBackground/ToughnessContainer")
 cost_container = NodePath("card/CastingCostSprite")
 sound_resource = ExtResource("2_r6i3w")
+
+[node name="DamageIndicatorSprite" type="Sprite3D" parent="."]
+transform = Transform3D(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+double_sided = false
+alpha_cut = 3
+texture = SubResource("ViewportTexture_1snw7")
 
 [node name="card" type="Node3D" parent="."]
 transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 0, 0, 0)
@@ -486,7 +626,7 @@ transform = Transform3D(0.64, 0, 0, 0, 0.64, 0, 0, 0, 1, 0, -0.236297, 0.0206564
 texture = SubResource("ViewportTexture_nflyd")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, -0.00283813, -0.098938, 0.00246477)
+transform = Transform3D(0.5, 0, 0, 0, 0.5, 0, 0, 0, 0.5, -0.0409518, -0.0836923, 0.00246477)
 shape = SubResource("BoxShape3D_huxpf")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -641,7 +781,6 @@ theme = ExtResource("8_lkgco")
 theme_override_styles/panel = SubResource("StyleBoxEmpty_bqnan")
 
 [node name="TextureRect" type="TextureRect" parent="TitleViewport/Panel"]
-visible = false
 layout_mode = 1
 anchors_preset = 4
 anchor_top = 0.5
@@ -726,7 +865,6 @@ theme = ExtResource("8_lkgco")
 theme_override_styles/panel = SubResource("StyleBoxEmpty_bqnan")
 
 [node name="TextureRect" type="TextureRect" parent="PowerToughnessViewport/Panel"]
-visible = false
 layout_mode = 1
 anchors_preset = 4
 anchor_top = 0.5
@@ -912,3 +1050,40 @@ scroll_active = false
 autowrap_mode = 0
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="DamageIndicatorViewport" type="SubViewport" parent="."]
+transparent_bg = true
+size = Vector2i(128, 128)
+render_target_update_mode = 4
+
+[node name="DamageIndicatorPanel" type="Panel" parent="DamageIndicatorViewport"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_2upq3")
+
+[node name="DamageIndicatorLabel" type="RichTextLabel" parent="DamageIndicatorViewport/DamageIndicatorPanel"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -12.0
+offset_top = -27.5
+offset_right = 12.0
+offset_bottom = 27.5
+grow_horizontal = 2
+grow_vertical = 2
+pivot_offset = Vector2(64, 61)
+theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_colors/font_shadow_color = Color(0.2757, 0.2757, 0.2757, 1)
+theme_override_font_sizes/normal_font_size = 40
+theme_override_font_sizes/bold_font_size = 40
+bbcode_enabled = true
+text = "[color=ff0000][center][b]-5[/b][/center]"
+fit_content = true
+scroll_active = false
+autowrap_mode = 0

--- a/components/card_prefab.tscn
+++ b/components/card_prefab.tscn
@@ -267,6 +267,110 @@ tracks/6/keys = {
 "values": [Vector3(0, 0, 0)]
 }
 
+[sub_resource type="Animation" id="Animation_dobx1"]
+resource_name = "damaged"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("card:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape3D:rotation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DamageIndicatorSprite:position")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DamageIndicatorSprite:scale")
+tracks/3/interp = 2
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.333333, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
+}
+
+[sub_resource type="Animation" id="Animation_q22v4"]
+resource_name = "damaged_tapped"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("card:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape3D:rotation")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
+"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("DamageIndicatorSprite:position")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
+}
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("DamageIndicatorSprite:scale")
+tracks/3/interp = 2
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.333333, 0.5),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
+}
+
 [sub_resource type="Animation" id="Animation_h51jn"]
 resource_name = "hover_begin"
 length = 0.1
@@ -435,110 +539,6 @@ tracks/1/keys = {
 "transitions": PackedFloat32Array(0.3, 1),
 "update": 0,
 "values": [Vector3(0, 0, -1.5708), Vector3(0, 0, 0)]
-}
-
-[sub_resource type="Animation" id="Animation_dobx1"]
-resource_name = "damaged"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("card:rotation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CollisionShape3D:rotation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(0, 0, 0.414097), Vector3(0, 0, -0.429595), Vector3(0, 0, 0.414097), Vector3(0, 0, 0)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("DamageIndicatorSprite:position")
-tracks/2/interp = 2
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("DamageIndicatorSprite:scale")
-tracks/3/interp = 2
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0, 0.333333, 0.5),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
-}
-
-[sub_resource type="Animation" id="Animation_q22v4"]
-resource_name = "damaged_tapped"
-length = 0.5
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("card:rotation")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = true
-tracks/1/path = NodePath("CollisionShape3D:rotation")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 0.0333333, 0.1, 0.166667, 0.266667),
-"transitions": PackedFloat32Array(0.3, 1, 1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, -1.5708), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.15192), Vector3(0, 0, -1.97222), Vector3(0, 0, -1.5708)]
-}
-tracks/2/type = "value"
-tracks/2/imported = false
-tracks/2/enabled = true
-tracks/2/path = NodePath("DamageIndicatorSprite:position")
-tracks/2/interp = 2
-tracks/2/loop_wrap = true
-tracks/2/keys = {
-"times": PackedFloat32Array(0, 0.5),
-"transitions": PackedFloat32Array(1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0.025), Vector3(0, 1, 0.025)]
-}
-tracks/3/type = "value"
-tracks/3/imported = false
-tracks/3/enabled = true
-tracks/3/path = NodePath("DamageIndicatorSprite:scale")
-tracks/3/interp = 2
-tracks/3/loop_wrap = true
-tracks/3/keys = {
-"times": PackedFloat32Array(0, 0.333333, 0.5),
-"transitions": PackedFloat32Array(1, 1, 1),
-"update": 0,
-"values": [Vector3(0, 0, 0), Vector3(2, 2, 2), Vector3(0, 0, 0)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_cjtkg"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -490,13 +490,15 @@ double_sided = false
 alpha_cut = 1
 texture = ExtResource("16_sjurj")
 
-[node name="MyAvatar" parent="." node_paths=PackedStringArray("graveyard") instance=ExtResource("21_5rpq5")]
+[node name="MyAvatar" parent="." node_paths=PackedStringArray("graveyard", "main_camera") instance=ExtResource("21_5rpq5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.63062, 4.05117)
 graveyard = NodePath("../Card Groups/Mine/MyGraveyard")
+main_camera = NodePath("../Camera3D")
 
-[node name="OpponentAvatar" parent="." node_paths=PackedStringArray("graveyard") instance=ExtResource("21_5rpq5")]
+[node name="OpponentAvatar" parent="." node_paths=PackedStringArray("graveyard", "main_camera") instance=ExtResource("21_5rpq5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.12341, 4.38049)
 graveyard = NodePath("../Card Groups/Opponent/OpponentGraveyard")
+main_camera = NodePath("../Camera3D")
 
 [node name="Main Canvas" type="CanvasLayer" parent="."]
 

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -491,7 +491,6 @@ alpha_cut = 1
 texture = ExtResource("16_sjurj")
 
 [node name="MyAvatar" parent="." node_paths=PackedStringArray("graveyard") instance=ExtResource("21_5rpq5")]
-process_mode = 4
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.63062, 4.05117)
 graveyard = NodePath("../Card Groups/Mine/MyGraveyard")
 

--- a/scripts/Avatar.gd
+++ b/scripts/Avatar.gd
@@ -19,9 +19,15 @@ func _process(delta: float) -> void:
 	pass
 
 func damage(amount: int) -> void:
+	
+	# Handle damage label
+	var anim_player: AnimationPlayer = $AnimationPlayer
 	if amount > 0:
 		damage_indicator_label.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
-		$AnimationPlayer.play("avatar_damaged")
+	elif amount < 0:
+		damage_indicator_label.text = "[color=00ff00][center][b]+" + str(-amount) + "[/b][/center]"
+	if amount != 0: anim_player.play("avatar_damaged")
+	
 	print(str(self.name) + " got damaged for " + str(amount))
 	toughness -= amount
 	refresh()

--- a/scripts/Avatar.gd
+++ b/scripts/Avatar.gd
@@ -2,6 +2,7 @@ class_name Avatar
 extends Node3D
 
 @export var toughness_text : Node
+@export var damage_indicator_label : RichTextLabel
 var toughness : int = 20
 var power : int = 0
 var card_group_controller : Node = null
@@ -18,10 +19,12 @@ func _process(delta: float) -> void:
 	pass
 
 func damage(amount: int) -> void:
+	if amount > 0:
+		damage_indicator_label.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
+		$AnimationPlayer.play("avatar_damaged")
 	print(str(self.name) + " got damaged for " + str(amount))
 	toughness -= amount
 	refresh()
-#	
 	if toughness <= 0:
 		get_tree().change_scene_to_packed(load("res://scenes/gameover.tscn"))
 

--- a/scripts/Avatar.gd
+++ b/scripts/Avatar.gd
@@ -9,7 +9,7 @@ var card_group_controller : Node = null
 var hovered = false
 @export var graveyard : Node = null 	# the graveyard associated w/ this card group controller
 var type = Avatar
-
+@export var main_camera : Camera3D = null
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	refresh()
@@ -23,6 +23,7 @@ func damage(amount: int) -> void:
 	# Handle damage label
 	var anim_player: AnimationPlayer = $AnimationPlayer
 	if amount > 0:
+		await main_camera.initiate_camera_shake(amount, 10)
 		damage_indicator_label.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
 	elif amount < 0:
 		damage_indicator_label.text = "[color=00ff00][center][b]+" + str(-amount) + "[/b][/center]"

--- a/scripts/CardController.gd
+++ b/scripts/CardController.gd
@@ -27,6 +27,7 @@ var queue = []
 @export var label_description : RichTextLabel
 @export var label_type : RichTextLabel
 @export var label_damage_indicator : RichTextLabel
+@export var label_asleep_indicator : RichTextLabel
 @export var power_container : Node
 @export var toughness_container : Node
 @export var cost_container : Node
@@ -44,6 +45,7 @@ func _ready() -> void:
 	if sound_resource == null:
 		sound_resource = load("res://sounds/defaults.tres")
 	self.name = card_name
+	label_asleep_indicator.visible = false
 	original_basis = self.transform.basis
 	anim_player = $AnimationPlayer
 	anim_player.connect("animation_finished", Callable(self, "_on_animation_finished"))
@@ -124,9 +126,11 @@ func on_clicked() -> void:
 
 func do_tap() -> void:	
 	tapped = !tapped
-	queue.append("tap" if tapped else "untap")
-	if not tapped:
-		Audio.play(sound_resource.sounds.get("untap"))
+	label_asleep_indicator.visible = tapped # TODO: Add animations
+	
+	#queue.append("tap" if tapped else "untap")
+	#if not tapped:
+		#Audio.play(sound_resource.sounds.get("untap"))
 	
 func do_turn():
 	turned = !turned
@@ -162,7 +166,7 @@ func damage(amount):
 	elif amount < 0:
 		label_damage_indicator.text = "[color=00ff00][center][b]+" + str(-amount) + "[/b][/center]"
 	if amount != 0: 
-		queue.append("damaged" if not tapped else "damaged_tapped")
+		queue.append("damaged")
 	refresh_power_toughness()
 	
 func is_dead():

--- a/scripts/CardController.gd
+++ b/scripts/CardController.gd
@@ -155,8 +155,13 @@ func damage(amount):
 	Audio.play(sound_resource.sounds.get("hit"))
 	print(str(self.name) + " got damaged for " + str(amount))
 	current_toughness -= amount
-	label_damage_indicator.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
-	if amount > 0: 
+	
+	var anim_player: AnimationPlayer = $AnimationPlayer
+	if amount > 0:
+		label_damage_indicator.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
+	elif amount < 0:
+		label_damage_indicator.text = "[color=00ff00][center][b]+" + str(-amount) + "[/b][/center]"
+	if amount != 0: 
 		queue.append("damaged" if not tapped else "damaged_tapped")
 	refresh_power_toughness()
 	

--- a/scripts/CardController.gd
+++ b/scripts/CardController.gd
@@ -26,6 +26,7 @@ var queue = []
 @export var label_subtype : RichTextLabel
 @export var label_description : RichTextLabel
 @export var label_type : RichTextLabel
+@export var label_damage_indicator : RichTextLabel
 @export var power_container : Node
 @export var toughness_container : Node
 @export var cost_container : Node
@@ -154,6 +155,9 @@ func damage(amount):
 	Audio.play(sound_resource.sounds.get("hit"))
 	print(str(self.name) + " got damaged for " + str(amount))
 	current_toughness -= amount
+	label_damage_indicator.text = "[color=ff0000][center][b]" + str(-amount) + "[/b][/center]"
+	if amount > 0: 
+		queue.append("damaged" if not tapped else "damaged_tapped")
 	refresh_power_toughness()
 	
 func is_dead():

--- a/scripts/MouseHandler.gd
+++ b/scripts/MouseHandler.gd
@@ -11,11 +11,31 @@ var click_threshold = 10  # Distance threshold to differentiate between click an
 var clicked_card = null
 var group_dragged_from = null
 var old_drop_point = null
+
 @export var game_logic = Node
 const CardType = preload("res://scripts/CardController.gd").CardType
 @export var arrow_controller : Control
 @export var sound_resource : Resource
 var mouse_hovering_battlefield = false
+
+var rng = RandomNumberGenerator.new()
+var shake_strength = 0
+var shake_fade_speed = 1
+var inital_position: Vector3 = position
+func _process(delta: float) -> void: 
+	if shake_strength > 0:
+		shake_strength = lerp(shake_strength, 0.0, shake_fade_speed*delta)
+		position = inital_position + Vector3(rng.randf_range(-shake_strength, shake_strength), rng.randf_range(-shake_strength, shake_strength), 0.0)
+	else:
+		position = inital_position
+
+func initiate_camera_shake(strength: float, fade_speed: float) -> void:
+	var inital_position: Vector3 = position
+	shake_strength = strength
+	shake_fade_speed = fade_speed
+	
+
+
 
 func get_drop_point(mouse_position:Vector2):
 	if mouse_hovering_battlefield:


### PR DESCRIPTION
Added "damaged" and "damaged_tapped" animations for the cards, and added "damaged" animation for the avatar.

The card animations shake the card and show a damage indicator. The avatar's animation has no shake, but shows a damage indicator.

Also removed the tapping animations in favor of an "Asleep" label on the cards, a better solution is probably needed but this will work for now.